### PR TITLE
Fix cylinder rotation

### DIFF
--- a/Cylindrical.m
+++ b/Cylindrical.m
@@ -36,7 +36,11 @@
               sin(obj.theta)    0       cos(obj.theta)   0
               0             0              0     1];
           tform = affine3d(t);
-          obj.volume = imwarp(obj.volume,tform);
+          obj.volume = imwarp(obj.volume,tform, 'FillValues', obj.sus(2));
+
+          % Troncate the rotated volume to the desired size
+          margins = ((size(obj.volume)-obj.matrix) / 2);
+          obj.volume = obj.volume(1 + margins(1):margins(1) + obj.matrix(1), 1 + margins(2):margins(2) + obj.matrix(2), 1 + margins(3):margins(3) + obj.matrix(3));
             
        end
        


### PR DESCRIPTION
When the cylinder was rotated, the volume was filled with zeros and its dimensions were stretched.
Here the 'FillValues' parameter of imwarp is used and the volume is troncated to the desired dimensions while keeping the center of the cylinder at the center of the volume.