### PR TITLE
Typing issue + Saving Zubal

### DIFF
--- a/FBFest.m
+++ b/FBFest.m
@@ -86,12 +86,13 @@ classdef FBFest < handle
                         nii_vol = make_nii(real(1e6*vol)); % save real part in ppm
                     else
                         nii_vol = make_nii(imrotate(fliplr(real(1e6*vol)), -90)); % save real part in ppm
-                        
-                        set image resolution in nifti header
-                        nii_vol.hdr.dime.pixdim(2) = obj.image_res(1);
-                        nii_vol.hdr.dime.pixdim(3) = obj.image_res(2);
-                        nii_vol.hdr.dime.pixdim(4) = obj.image_res(3);
                     end
+                       
+                    %set image resolution in nifti header
+                    nii_vol.hdr.dime.pixdim(2) = obj.image_res(1);
+                    nii_vol.hdr.dime.pixdim(3) = obj.image_res(2);
+                    nii_vol.hdr.dime.pixdim(4) = obj.image_res(3);
+
                     
                     save_nii(nii_vol, [fileName '.nii']);
                     

--- a/Zubal.m
+++ b/Zubal.m
@@ -6,8 +6,8 @@
        function obj = Zubal(zubal_fname)
           % Method Zubal (constructor)
           % must be used with a modified zubal phantom (distribution is not
-          % posssible, as per the conditions of the original zubal phantom): zubal_fname
-          % the orignial zubal phantom can be found here: http://noodle.med.yale.edu/zubal/data.htm
+          % possible, as per the conditions of the original zubal phantom): zubal_fname
+          % the original zubal phantom can be found here: http://noodle.med.yale.edu/zubal/data.htm
           
           % absolute susceptibility [ppm] values are from Buch et al. MRM 73:2185?2194 (2015)
           % susceptibility of fat is from https://onlinelibrary.wiley.com/doi/full/10.1002/mrm.27640


### PR DESCRIPTION
This pull request consists of two commits :
- A little correction of a typing error in _Zubal.m_ ;
- A correction in _FBFest.m_, in the method _save_. When saving an object of type 'Zubal', the _pixelDim_ parameter of the NIFTI was not saved, whereas it was done for the other types of object. I think it was forgotten as I see no reason not to do so. I saved a file of Zubal type and indeed the pixel dimensions (pixelDims) were not correct.